### PR TITLE
Add Command for Viewing future tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ you to easily move tasks between different todo lists.
    before bumping to the next day.
  * verify - Search all files for unmanaged tasks (those that haven't been
    completed and/or bumped to a later day)
+ * future - Print list of upcoming tasks. Shown as a tree where each day is a
+   node.
  * bringforward - bring all the tasks you forgot to manage on to today's todo
    list.
 

--- a/node.py
+++ b/node.py
@@ -1,0 +1,16 @@
+
+class Node:
+    def __init__(self, value=None, children=None):
+        if children is None:
+            children = []
+        self.value, self.children = value, children
+
+
+def pprint_tree(node, file=None, _prefix="", _last=True):
+    print(_prefix, "`- " if _last else "|- ", node.value, sep="", file=file)
+    _prefix += "   " if _last else "|  "
+    child_count = len(node.children)
+    for i, child in enumerate(node.children):
+        _last = i == (child_count - 1)
+        pprint_tree(child, file, _prefix, _last)
+

--- a/tmsa
+++ b/tmsa
@@ -33,6 +33,7 @@ from node import Node, pprint_tree
 # https://pypi.org/project/termcolor/
 day_color = 'red'
 day_attrs = ['bold']
+day_format = "%b %d"
 
 try: from termcolor import colored
 except ImportError:
@@ -98,7 +99,19 @@ def find_unmanaged():
                    unmanaged.append(f)
     return unmanaged
 
-def find_future():
+def decode_recurcmd(cmdstr):
+    "Return a dictionary with 'day', 'task', and a list 'weeks'"
+    result = {}
+    precol,postcol = cmdstr.split(':')
+    time_pos = precol.rsplit(maxsplit=1)
+    result['day'] = time_pos[-1].strip().lower()
+    result['weeks'] = []
+    if len(time_pos) > 1:
+        result['weeks'] = [week.strip() for week in time_pos[0].split(',')]
+    result['task'] = postcol.strip()
+    return result
+
+def find_future_files():
     "Find files which occur after today"
     files = []
     today = datetime.datetime.now().replace(hour=0, minute=0, second=0,
@@ -110,22 +123,57 @@ def find_future():
         size = os.stat(fn).st_size
         if datetime.datetime.strptime(d, "%Y-%m-%d") > today and size > 0:
             files.append(fn)
-
     return files
 
+def get_future_remcur():
+    result = {}
+    # today = datetime.datetime.now().replace(hour=0, minute=0, second=0,
+    #                                       microsecond=0)
+    today = datetime.date.today()
+    days = [day.lower() for day in calendar.weekheader(10).split()]
+    numbers = ["first", "second", "third", "fourth", "five"]
+    with open("recur.txt", 'r') as f:
+        recur_tasks = [decode_recurcmd(line.strip()) for line in f if not
+                line.isspace()]
+    found_tr_day = None
+    for task_rule in recur_tasks:
+        if task_rule['weeks']:
+            day_index = days.index(task_rule['day'])
+            cal = calendar.Calendar(day_index).monthdatescalendar(today.year,
+                    today.month)
+            for week in task_rule['weeks']:
+                try:
+                    wn = numbers.index(week)+1
+                except(ValueError):
+                    if week == 'last':
+                        wn = -1
+                    else:
+                        raise ValueError("%s is not a week name" % week)
+                found_tr_day = cal[wn][0]
+                if found_tr_day > today: break
+                else: found_tr_day = None
+        else:
+            wdnum = today.weekday()
+            diff = days.index(task_rule['day']) - wdnum
+            if diff < 0: diff += 7
+            found_tr_day = today+datetime.timedelta(diff)
 
-def gen_tree(files):
-    "Generate a list of nodes for each file. List of files as input"
-    day_nodes = []
-    for day in files:
-        day_base = os.path.splitext(day)[0]
-        day_obj = datetime.datetime.strptime(day_base, "%Y-%m-%d")
-        day_pn = day_obj.strftime("%b %d")
-        with open(day) as content:
-            day_nodes.append(Node(colored(day_pn, day_color, attrs=day_attrs)
-                if enableColoring else day_pn, [Node(line.strip()) for line in
-                    content.readlines() if not line.isspace()]))
+        if found_tr_day is not None:
+            if found_tr_day in result:
+                result[found_tr_day].append(task_rule['task'])
+            else:
+                result[found_tr_day] = [task_rule['task']]
+    return result
 
+def gen_tree(tasks):
+    "Generate a list of nodes for the given task dictionary in order"
+    pretty_tasks = {}
+    for date in sorted(tasks):
+        pretty_tasks[date.strftime(day_format)] = tasks[date]
+
+    day_nodes = [Node(colored(k, day_color, attrs=day_attrs) if enableColoring
+        else k, [Node(t) for t in pretty_tasks[k]]) for k in pretty_tasks if
+        pretty_tasks[k]]
     return day_nodes
 
 
@@ -199,7 +247,27 @@ if __name__ == '__main__':
         sys.exit(0)
 
     if action == 'future':
-        day_nodes = gen_tree(find_future())
+        tasks = {}
+        files = find_future_files()
+        for day in files:
+            day_base = os.path.splitext(day)[0]
+            day_obj = datetime.datetime.strptime(day_base, "%Y-%m-%d").date()
+            with open(day) as f:
+                tasks[day_obj] = [line.strip() for line in f if not
+                        line.isspace()]
+
+        if os.path.exists("recur.txt"):
+            import calendar
+            tfr = get_future_remcur()
+            # Merge the two
+            for task in tasks:
+                if task in tfr:
+                    tasks[task] += tfr[task]
+                    del tfr[task]
+                    break
+            tasks |= tfr
+
+        day_nodes = gen_tree(tasks)
         for tree in day_nodes:
             pprint_tree(tree)
             print()

--- a/tmsa
+++ b/tmsa
@@ -28,12 +28,15 @@ import re
 import sys
 from node import Node, pprint_tree
 
+# OPTIONS
 # Text attributes for coloring and boldness
 # See the termcolor documentation for more options:
 # https://pypi.org/project/termcolor/
 day_color = 'red'
 day_attrs = ['bold']
 day_format = "%b %d"
+# Show task using the weekday name instead of the day format
+day_name_if_soon = True
 
 try: from termcolor import colored
 except ImportError:
@@ -168,9 +171,12 @@ def get_future_remcur():
 def gen_tree(tasks):
     "Generate a list of nodes for the given task dictionary in order"
     pretty_tasks = {}
+    today = datetime.date.today()
     for date in sorted(tasks):
-        pretty_tasks[date.strftime(day_format)] = tasks[date]
+        pretty_tasks[date.strftime('%A' if day_name_if_soon and date - today <
+            datetime.timedelta(weeks=1) else day_format)] = tasks[date]
 
+    # Since Python 3.6 dictionaries remember order insertion
     day_nodes = [Node(colored(k, day_color, attrs=day_attrs) if enableColoring
         else k, [Node(t) for t in pretty_tasks[k]]) for k in pretty_tasks if
         pretty_tasks[k]]

--- a/tmsa
+++ b/tmsa
@@ -49,7 +49,8 @@ commands = {
     'bump': ["Bump a task to the next day", "For example, bump 2"],
     'bumpall': ["Bump all tasks to the next day"],
     'verify': ["Print out to do files that have unmanaged active tasks"],
-    'future': ["Print a tree of all the future tasks"],
+    'future': ["Print a tree of all the future tasks", "Give a number to limit\
+ it by that number of weeks into the future"],
     'tmsa': [
         "Time management for systems administrators helper script.",
         "Provides a set of commands to help with the Cycle, which",
@@ -255,6 +256,11 @@ if __name__ == '__main__':
     if action == 'future':
         tasks = {}
         files = find_future_files()
+        if len(sys.argv) > 2:
+            limit = datetime.timedelta(weeks = int(sys.argv[2]))
+        else:
+            limit = datetime.timedelta.max
+
         for day in files:
             day_base = os.path.splitext(day)[0]
             day_obj = datetime.datetime.strptime(day_base, "%Y-%m-%d").date()
@@ -273,6 +279,10 @@ if __name__ == '__main__':
                     break
             tasks |= tfr
 
+        today = datetime.date.today()
+        for date in tasks.copy():
+            if date - today > limit:
+                tasks.pop(date)
         day_nodes = gen_tree(tasks)
         for tree in day_nodes:
             pprint_tree(tree)

--- a/tmsa
+++ b/tmsa
@@ -26,12 +26,26 @@ import glob
 import os
 import re
 import sys
+from node import Node, pprint_tree
+
+# Text attributes for coloring and boldness
+# See the termcolor documentation for more options:
+# https://pypi.org/project/termcolor/
+day_color = 'red'
+day_attrs = ['bold']
+
+try: from termcolor import colored
+except ImportError:
+    enableColoring = False
+else:
+    enableColoring = True
 
 commands = {
     'bringforward': ["Bring forward any unmanaged tasks to today"],
     'bump': ["Bump a task to the next day", "For example, bump 2"],
     'bumpall': ["Bump all tasks to the next day"],
     'verify': ["Print out to do files that have unmanaged active tasks"],
+    'future': ["Print a tree of all the future tasks"],
     'tmsa': [
         "Time management for systems administrators helper script.",
         "Provides a set of commands to help with the Cycle, which",
@@ -83,6 +97,36 @@ def find_unmanaged():
                 if undone_lines(fh):
                    unmanaged.append(f)
     return unmanaged
+
+def find_future():
+    "Find files which occur after today"
+    files = []
+    today = datetime.datetime.now().replace(hour=0, minute=0, second=0,
+                                          microsecond=0)
+    os.chdir(os.environ["TODO_DIR"])
+
+    for fn in sorted(glob.iglob("????-??-??.txt")):
+        d, e = fn.split(".")
+        size = os.stat(fn).st_size
+        if datetime.datetime.strptime(d, "%Y-%m-%d") > today and size > 0:
+            files.append(fn)
+
+    return files
+
+
+def gen_tree(files):
+    "Generate a list of nodes for each file. List of files as input"
+    day_nodes = []
+    for day in files:
+        day_base = os.path.splitext(day)[0]
+        day_obj = datetime.datetime.strptime(day_base, "%Y-%m-%d")
+        day_pn = day_obj.strftime("%b %d")
+        with open(day) as content:
+            day_nodes.append(Node(colored(day_pn, day_color, attrs=day_attrs)
+                if enableColoring else day_pn, [Node(line.strip()) for line in
+                    content.readlines() if not line.isspace()]))
+
+    return day_nodes
 
 
 def bump(from_file, to_file, line_num=None):
@@ -153,6 +197,12 @@ if __name__ == '__main__':
         if unmanaged:
             print('\n'.join(sorted(find_unmanaged())))
         sys.exit(0)
+
+    if action == 'future':
+        day_nodes = gen_tree(find_future())
+        for tree in day_nodes:
+            pprint_tree(tree)
+            print()
 
     if action == 'bump' or action == 'bumpall':
         to_bump = None

--- a/tmsa
+++ b/tmsa
@@ -170,16 +170,16 @@ def get_future_remcur():
 
 def gen_tree(tasks):
     "Generate a list of nodes for the given task dictionary in order"
-    pretty_tasks = {}
+    trans = {} # a copy of tasks transformed for pretty keys
     today = datetime.date.today()
     for date in sorted(tasks):
-        pretty_tasks[date.strftime('%A' if day_name_if_soon and date - today <
-            datetime.timedelta(weeks=1) else day_format)] = tasks[date]
+        pretty_key = date.strftime('%A' if day_name_if_soon and date - today <
+                datetime.timedelta(weeks=1) else day_format)
+        pretty_key = colored(pretty_key, day_color, attrs=day_attrs) if enableColoring else pretty_key
+        trans[pretty_key] = tasks[date]
 
     # Since Python 3.6 dictionaries remember order insertion
-    day_nodes = [Node(colored(k, day_color, attrs=day_attrs) if enableColoring
-        else k, [Node(t) for t in pretty_tasks[k]]) for k in pretty_tasks if
-        pretty_tasks[k]]
+    day_nodes = [Node(k, [Node(t) for t in trans[k]]) for k in trans if trans[k]]
     return day_nodes
 
 

--- a/tmsa
+++ b/tmsa
@@ -159,7 +159,7 @@ def get_future_remcur():
         else:
             wdnum = today.weekday()
             diff = days.index(task_rule['day']) - wdnum
-            if diff < 0: diff += 7
+            if diff <= 0: diff += 7
             found_tr_day = today+datetime.timedelta(diff)
 
         if found_tr_day is not None:
@@ -173,10 +173,16 @@ def gen_tree(tasks):
     "Generate a list of nodes for the given task dictionary in order"
     trans = {} # a copy of tasks transformed for pretty keys
     today = datetime.date.today()
+    one_week = datetime.timedelta(weeks=1)
     for date in sorted(tasks):
-        pretty_key = date.strftime('%A' if day_name_if_soon and date - today <
-                datetime.timedelta(weeks=1) else day_format)
-        pretty_key = colored(pretty_key, day_color, attrs=day_attrs) if enableColoring else pretty_key
+        diff = date - today
+        pretty_key = date.strftime('%A' if day_name_if_soon and diff <=
+                one_week else day_format)
+        if diff == one_week:
+            pretty_key = "Next " + pretty_key
+        if enableColoring:
+            pretty_key = colored(pretty_key, day_color, attrs=day_attrs)
+
         trans[pretty_key] = tasks[date]
 
     # Since Python 3.6 dictionaries remember order insertion

--- a/tmsa
+++ b/tmsa
@@ -106,7 +106,7 @@ def find_unmanaged():
 def decode_recurcmd(cmdstr):
     "Return a dictionary with 'day', 'task', and a list 'weeks'"
     result = {}
-    precol,postcol = cmdstr.split(':')
+    precol,postcol = cmdstr.split(':', 1)
     time_pos = precol.rsplit(maxsplit=1)
     result['day'] = time_pos[-1].strip().lower()
     result['weeks'] = []
@@ -283,7 +283,7 @@ if __name__ == '__main__':
                     tasks[task] += tfr[task]
                     del tfr[task]
                     break
-            tasks |= tfr
+            tasks.update(tfr)
 
         today = datetime.date.today()
         for date in tasks.copy():


### PR DESCRIPTION
There's no easy way to view bumped tasks, so I made one.

I want to make this list recurring tasks from [todo.txt-recur](https://github.com/paulroub/todo.txt-recurring-tasks) as well, but I'm not sure if compatibility with other addons is something you'd want.

There's also the optional dependancy [termcolor](https://pypi.org/project/termcolor/) which colors the dates. I forgot to mention that in the README.